### PR TITLE
Explicit attributes parameter

### DIFF
--- a/Sources/FileManagerKit/FileManager+Kit.swift
+++ b/Sources/FileManagerKit/FileManager+Kit.swift
@@ -128,9 +128,7 @@ extension FileManager: FileManagerKit {
     /// - Throws: An error if the directory could not be created.
     public func createDirectory(
         at url: URL,
-        attributes: [FileAttributeKey: Any]? = [
-            .posixPermissions: 0o744
-        ]
+        attributes: [FileAttributeKey: Any]?
     ) throws {
         guard !directoryExists(at: url) else {
             return
@@ -152,7 +150,7 @@ extension FileManager: FileManagerKit {
     public func createFile(
         at url: URL,
         contents: Data?,
-        attributes: [FileAttributeKey: Any]? = nil
+        attributes: [FileAttributeKey: Any]?
     ) throws {
         guard
             createFile(
@@ -192,7 +190,7 @@ extension FileManager: FileManagerKit {
             return
         }
         if !directoryExists(at: outputURL) {
-            try createDirectory(at: outputURL)
+            try createDirectory(at: outputURL, attributes: nil)
         }
 
         for item in listDirectory(at: inputURL) {

--- a/Tests/FileManagerKitTests/FileManagerKitTestSuite.swift
+++ b/Tests/FileManagerKitTests/FileManagerKitTestSuite.swift
@@ -142,7 +142,7 @@ struct FileManagerKitTestSuite {
         try FileManagerPlayground()
             .test { fileManager, rootUrl in
                 let url = rootUrl.appending(path: "foo/bar/baz")
-                
+
                 #expect(
                     throws: CocoaError(.fileWriteUnknown),
                     performing: {

--- a/Tests/FileManagerKitTests/FileManagerKitTestSuite.swift
+++ b/Tests/FileManagerKitTests/FileManagerKitTestSuite.swift
@@ -127,7 +127,11 @@ struct FileManagerKitTestSuite {
         try FileManagerPlayground()
             .test {
                 let url = $1.appending(path: "foo")
-                try $0.createFile(at: url, contents: nil)
+                try $0.createFile(
+                    at: url,
+                    contents: nil,
+                    attributes: nil
+                )
 
                 #expect($0.fileExists(at: url))
             }
@@ -138,11 +142,15 @@ struct FileManagerKitTestSuite {
         try FileManagerPlayground()
             .test { fileManager, rootUrl in
                 let url = rootUrl.appending(path: "foo/bar/baz")
-
+                
                 #expect(
                     throws: CocoaError(.fileWriteUnknown),
                     performing: {
-                        try fileManager.createFile(at: url, contents: nil)
+                        try fileManager.createFile(
+                            at: url,
+                            contents: nil,
+                            attributes: nil
+                        )
                     }
                 )
             }
@@ -158,7 +166,11 @@ struct FileManagerKitTestSuite {
         .test {
             let url = $1.appending(path: "foo/bar")
             let dataToWrite = "data".data(using: .utf8)
-            try $0.createFile(at: url, contents: dataToWrite)
+            try $0.createFile(
+                at: url,
+                contents: dataToWrite,
+                attributes: nil
+            )
             let data = $0.contents(atPath: url.path(percentEncoded: false))
 
             #expect(dataToWrite == data)
@@ -172,7 +184,10 @@ struct FileManagerKitTestSuite {
         try FileManagerPlayground()
             .test {
                 let url = $1.appending(path: "foo")
-                try $0.createDirectory(at: url)
+                try $0.createDirectory(
+                    at: url,
+                    attributes: nil
+                )
 
                 #expect($0.directoryExists(at: url))
             }
@@ -187,7 +202,10 @@ struct FileManagerKitTestSuite {
         }
         .test {
             let url = $1.appending(path: "foo/bar")
-            try $0.createDirectory(at: url)
+            try $0.createDirectory(
+                at: url,
+                attributes: nil
+            )
 
             #expect($0.directoryExists(at: url))
         }


### PR DESCRIPTION
Since the current protocol design won't allow us to provide a default attributes parameter, it's better to remove opinionated ones & using nil seems to be a bad thing.